### PR TITLE
Update load_data.py to work with sklearn.preprocessing.OneHotEncoder v1.2 updates

### DIFF
--- a/02_haxby_decoding/load_data.py
+++ b/02_haxby_decoding/load_data.py
@@ -96,7 +96,7 @@ def load_subject_meta(dataset, index=0, sessions=None, targets=None, **kwargs):
 
     # convert y to one-hot encoding
     from sklearn.preprocessing import OneHotEncoder
-    encoder = OneHotEncoder(handle_unknown='ignore', sparse=False)
+    encoder = OneHotEncoder(handle_unknown='ignore', sparse_output=False)
     y = encoder.fit_transform(np.c_[target])
     target = pd.DataFrame(y, columns=target_names)
 

--- a/02_haxby_decoding/load_data.py
+++ b/02_haxby_decoding/load_data.py
@@ -96,7 +96,12 @@ def load_subject_meta(dataset, index=0, sessions=None, targets=None, **kwargs):
 
     # convert y to one-hot encoding
     from sklearn.preprocessing import OneHotEncoder
-    encoder = OneHotEncoder(handle_unknown='ignore', sparse_output=False)
+	try: 
+		# scikit-learn version >= 1.2
+		encoder = OneHotEncoder(handle_unknown='ignore', sparse_output=False)
+	except TypeError:
+		# scikit-learn version < 1.2
+		encoder = OneHotEncoder(handle_unknown='ignore', sparse=False)
     y = encoder.fit_transform(np.c_[target])
     target = pd.DataFrame(y, columns=target_names)
 


### PR DESCRIPTION
New in scikit-learn version >= 1.2 : OneHotEncoder parameter `sparse` was renamed to `sparse_output`. Updated line `encoder = OneHotEncoder(handle_unknown='ignore', sparse=False)` in load_data.py. 